### PR TITLE
refactored keys 

### DIFF
--- a/test/HealthDRS-Sell.js
+++ b/test/HealthDRS-Sell.js
@@ -18,19 +18,36 @@ contract('HealthDRS :: Sell', function(accounts) {
     this.url = 'https://blogs.scientificamerican.com/observations/consciousness-goes-deeper-than-you-think/'    
   })
   
-  it('key owner should be able to put a key up for sale', async function() {
+  it('key owner should be able to put a key up for sale only if salable', async function() {
+    //root keys default to salable
     let tx1 = await this.drs.createKey(this.url)
     let key1 = tx1.logs[0].args._key
 
     await this.drs.createSalesOffer(key1, accounts[1], 5)
     let so = await this.drs.salesOffers(key1)
-    so[0].should.equal(accounts[1],'buyer did not correct address')
+    so[0].should.equal(accounts[1],'buyer was not correct address')
     so[1].should.be.bignumber.equal(5,'price was not set correctly')
 
-  })
+    //child keys default to non-salable
+    let tx2 = await this.drs.createChildKey(key1)
+    let childKey = tx2.logs[0].args._key
 
+    //should fail - having no permissions to sell
+    await this.drs.createSalesOffer(childKey, accounts[1], 5)
+    so = await this.drs.salesOffers(childKey)
+    so[0].should.not.equal(accounts[1])
+    so[1].should.not.be.bignumber.equal(5)
+
+    //give key permission to sell - should suceed
+    await this.drs.setKeyPermissions(key1, childKey, false, false, true)
+    await this.drs.createSalesOffer(childKey, accounts[1], 5)
+    so = await this.drs.salesOffers(childKey)
+    so[0].should.equal(accounts[1])
+    so[1].should.be.bignumber.equal(5)
+
+  })
+  
   it('putting a key up for sale should negate an active trade offer', async function() {
-    
     let tx1 = await this.drs.createKey(this.url)
     let key1 = tx1.logs[0].args._key
 
@@ -43,71 +60,65 @@ contract('HealthDRS :: Sell', function(accounts) {
     let to = await this.drs.tradeOffers(key1)
     to.should.equal('0x0000000000000000000000000000000000000000000000000000000000000000')
   })
-
+ 
   it('non owner should not be able to list a key for sale', async function() {
-    
-        let tx1 = await this.drs.createKey(this.url)
-        let key1 = tx1.logs[0].args._key
-    
-        //try to create a sales offer from the account that wants to buy a key
-        await this.drs.createSalesOffer(key1, accounts[1], 5, {from: accounts[1]})
-        let so = await this.drs.salesOffers(key1)
-        so[0].should.not.equal(accounts[1])
-        so[1].should.not.be.bignumber.equal(5)
+    let tx1 = await this.drs.createKey(this.url)
+    let key1 = tx1.logs[0].args._key
+
+    //try to create a sales offer from the account that wants to buy a key
+    await this.drs.createSalesOffer(key1, accounts[1], 5, {from: accounts[1]})
+    let so = await this.drs.salesOffers(key1)
+    so[0].should.not.equal(accounts[1])
+    so[1].should.not.be.bignumber.equal(5)
    })
 
    it('should not be able to purchase an unoffered key', async function() {
-    
-        let tx1 = await this.drs.createKey(this.url)
-        let key1 = tx1.logs[0].args._key
-    
-        this.token.transfer(accounts[1],1)
-        await this.token.approve(this.drs.address, 1, {from: accounts[1]})  
-        await this.drs.purchaseKey(key1, 1, {from: accounts[1]})
-        let owner = await this.drs.getKeyOwner(key1)
-        owner.should.equal(accounts[0])  
+    let tx1 = await this.drs.createKey(this.url)
+    let key1 = tx1.logs[0].args._key
+
+    this.token.transfer(accounts[1],1)
+    await this.token.approve(this.drs.address, 1, {from: accounts[1]})  
+    await this.drs.purchaseKey(key1, 1, {from: accounts[1]})
+    let owner = await this.drs.isOwner(key1,accounts[0])
+    owner.should.equal(true)  
    })
 
    it('should be able to purchase an offered key', async function() {
-    
-        let tx1 = await this.drs.createKey(this.url)
-        let key1 = tx1.logs[0].args._key
-        await this.drs.createSalesOffer(key1, accounts[1], 5)
+    let tx1 = await this.drs.createKey(this.url)
+    let key1 = tx1.logs[0].args._key
+    await this.drs.createSalesOffer(key1, accounts[1], 5)
 
-        //give account some HLTH to spend 
-        this.token.transfer(accounts[1],5)
-        await this.token.approve(this.drs.address, 5, {from: accounts[1]})  
-        await this.drs.purchaseKey(key1, 5, {from: accounts[1]})
+    //give account some HLTH to spend 
+    this.token.transfer(accounts[1],5)
+    await this.token.approve(this.drs.address, 5, {from: accounts[1]})  
+    await this.drs.purchaseKey(key1, 5, {from: accounts[1]})
 
-        let owner = await this.drs.getKeyOwner(key1)
-        owner.should.equal(accounts[1])  
+    let owner = await this.drs.isOwner(key1,accounts[1])
+    owner.should.equal(true)  
 
-        let balance = await this.token.balanceOf(accounts[0])
-        balance.should.be.bignumber.equal(100,'Should have gotten 5 tokens back')
-
+    let balance = await this.token.balanceOf(accounts[0])
+    balance.should.be.bignumber.equal(100,'Should have gotten 5 tokens back')
    })
 
    it('a key owner should be able to cancel a sales offer', async function() {
-    
-        let tx1 = await this.drs.createKey(this.url)
-        let key1 = tx1.logs[0].args._key
-        await this.drs.createSalesOffer(key1, accounts[1], 5)
-        await this.drs.cancelSalesOffer(key1)
-        let so = await this.drs.salesOffers(key1)
-        so[0].should.equal('0x0000000000000000000000000000000000000000')
+    let tx1 = await this.drs.createKey(this.url)
+    let key1 = tx1.logs[0].args._key
+    await this.drs.createSalesOffer(key1, accounts[1], 5)
+    await this.drs.cancelSalesOffer(key1)
+    let so = await this.drs.salesOffers(key1)
+    so[0].should.equal('0x0000000000000000000000000000000000000000')
    })
    
 
    it('a key owner should be able to update the price on a sales offer', async function() {
-    
-        let tx1 = await this.drs.createKey(this.url)
-        let key1 = tx1.logs[0].args._key
-        await this.drs.createSalesOffer(key1, accounts[1], 5)
-        
-        //overwrite old with new
-        await this.drs.createSalesOffer(key1, accounts[1], 50)        
-        let so = await this.drs.salesOffers(key1)
-        so[1].should.be.bignumber.equal(50)
+    let tx1 = await this.drs.createKey(this.url)
+    let key1 = tx1.logs[0].args._key
+    await this.drs.createSalesOffer(key1, accounts[1], 5)
+
+    //overwrite old with new
+    await this.drs.createSalesOffer(key1, accounts[1], 50)        
+    let so = await this.drs.salesOffers(key1)
+    so[1].should.be.bignumber.equal(50)
    })
 
 })

--- a/test/HealthDRS-Share.js
+++ b/test/HealthDRS-Share.js
@@ -18,17 +18,55 @@ contract('HealthDRS :: Share', function(accounts) {
   it('key owners should be able to share a key', async function() {
     let tx1 = await this.drs.createKey(this.url)
     let rootKey = tx1.logs[0].args._key
+    
+    let ownsKey = await this.drs.isOwner(rootKey, accounts[1])
+    ownsKey.should.equal(false)
 
-    let tx2 = await this.drs.createChildKey(rootKey) 
-    let childKey = tx2.logs[0].args._key   
+    //share key
+    await this.drs.shareKey(rootKey, accounts[1])
 
-    //create shared key
-    let tx3 = await this.drs.shareKey(rootKey, accounts[1])
-    let sharedKey = tx3.logs[0].args._key   
-
-    let isAncestor = await this.drs.isAncestor(sharedKey, childKey, {from: accounts[1]})
-    isAncestor.should.be.true
+    ownsKey = await this.drs.isOwner(rootKey, accounts[1])
+    ownsKey.should.equal(true)
 
   })
+
+  it('key owners should be able to unshare a key', async function() {
+    let tx1 = await this.drs.createKey(this.url)
+    let rootKey = tx1.logs[0].args._key
+    
+    let ownsKey = await this.drs.isOwner(rootKey, accounts[1])
+    ownsKey.should.equal(false)
+
+    //share key
+    await this.drs.shareKey(rootKey, accounts[1])
+
+    ownsKey = await this.drs.isOwner(rootKey, accounts[1])
+    ownsKey.should.equal(true)
+
+    await this.drs.unShareKey(rootKey, accounts[1])
+    ownsKey = await this.drs.isOwner(rootKey, accounts[1])
+    ownsKey.should.equal(false)
+
+  })
+
+  it('non-shareable key should not be able to share', async function() {
+    let tx1 = await this.drs.createKey(this.url)
+    let rootKey = tx1.logs[0].args._key
+    
+    //child key is not shareable by default
+    let tx2 = await this.drs.createChildKey(rootKey)
+    let childKey = tx2.logs[0].args._key
+
+    let ownsKey = await this.drs.isOwner(childKey, accounts[1])
+    ownsKey.should.equal(false)
+
+    //share key
+    await this.drs.shareKey(childKey, accounts[1])
+
+    ownsKey = await this.drs.isOwner(childKey, accounts[1])
+    ownsKey.should.equal(false)
+
+  })
+
 
 })

--- a/test/HealthDRS.js
+++ b/test/HealthDRS.js
@@ -18,8 +18,8 @@ contract('HealthDRS', function(accounts) {
   it('should be able to create a key', async function() {
     let tx = await this.drs.createKey('string')
     let key = tx.logs[0].args._key
-    let owner = await this.drs.getKeyOwner(key)
-    owner.should.equal(accounts[0]);    
+    let owner = await this.drs.isOwner(key,accounts[0])
+    owner.should.equal(true);    
   })
  
   it('should return the correct URL when passed a root key', async function() {
@@ -44,35 +44,15 @@ contract('HealthDRS', function(accounts) {
     tx2.logs[0].event.should.equal('KeyCreated')
     let key2 = tx2.logs[0].args._key    
     
-    let owner = await this.drs.getKeyOwner(key2)
-    owner.should.equal(accounts[0]);    
+    let owner = await this.drs.isOwner(key2,accounts[0])
+    owner.should.equal(true);    
   })
+
 
   it('should return the correct URL when passed a child key', async function() {
     let tx1 = await this.drs.createKey(this.url)
     let key1 = tx1.logs[0].args._key
     let tx2 = await this.drs.createChildKey(key1) 
-    let key2 = tx2.logs[0].args._key  
-
-    let url = await this.drs.getURL(key2) 
-    url.should.equal(this.url)    
-  })
-
-  it('should be able to create a peer key', async function() {
-    let tx1 = await this.drs.createKey(this.url)
-    let key1 = tx1.logs[0].args._key
-    let tx2 = await this.drs.createPeerKey(key1) 
-    tx2.logs[0].event.should.equal('KeyCreated')
-    let key2 = tx2.logs[0].args._key    
-    
-    let owner = await this.drs.getKeyOwner(key2)
-    owner.should.equal(accounts[0]);    
-  })
-
-  it('should return the correct URL when passed a peer key', async function() {
-    let tx1 = await this.drs.createKey(this.url)
-    let key1 = tx1.logs[0].args._key
-    let tx2 = await this.drs.createPeerKey(key1) 
     let key2 = tx2.logs[0].args._key  
 
     let url = await this.drs.getURL(key2) 
@@ -91,24 +71,6 @@ contract('HealthDRS', function(accounts) {
     let url = await this.drs.getURL(key2) 
     url.should.equal('changedUrl')    
   })
- 
-  it('should be able to clone a key you own', async function() {
-    let tx1 = await this.drs.createKey(this.url)
-    let key1 = tx1.logs[0].args._key
-    
-    let tx2 = await this.drs.createChildKey(key1) 
-    let key2 = tx2.logs[0].args._key  
-    
-    let tx3 = await this.drs.createCloneKey(key1)
-    let key3 = tx3.logs[0].args._key
 
-    //changing the url with the cloned key should 
-    //effect all the child keys of the original keys
-    await this.drs.updateURL(key3,'changedUrl')
-        
-    let url = await this.drs.getURL(key2) 
-    url.should.equal('changedUrl')        
-
-  })
 
 })


### PR DESCRIPTION
- removed the Rings struct, moving depth and parent to Keys, replacing primary and secondary. This removed all of the complex array referencing that was necessary in the recursive traversals.
- changed urls array to key -> string mapping 
- added in trading, selling, and sharing permissions - root keys default to true for all those, child keys default to false for all those. A key owner can only sell, trade, or share his or her key if they have those permissions. 
- Added a way to update these permission for owned ancestor keys. 
- Added in addressRecover - which is the ecrecover passthrough if someone wants to use ethereum for this.
- Refactored tests for all of the above
-  Added in new tests for the share, trade, sell permissions